### PR TITLE
DDCE-5190: Play 3.0 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,11 +11,9 @@ lazy val root = (project in file("."))
     DefaultBuildSettings.scalaSettings,
     DefaultBuildSettings.defaultSettings(),
     scalaVersion := "2.13.12",
-    // To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
-    libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always,
     Compile / unmanagedSourceDirectories += baseDirectory.value / "resources",
     scalacOptions ++= Seq(
-      "-Wconf:src=routes/.*:s",
+      "-Wconf:cat=unused-imports&src=routes/.*:s",
       "-Wconf:cat=unused-imports&src=views/.*:s"
     )
   )

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -2,4 +2,3 @@
 ->         /trusts-registration/agent-details             app.Routes
 ->         /                                              health.Routes
 
-GET        /admin/metrics             com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,26 +2,26 @@ import sbt.*
 
 object AppDependencies {
 
-  val bootstrapVersion = "7.23.0"
+  val bootstrapVersion = "8.5.0"
 
   val compile: Seq[ModuleID] = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"         %% "play-frontend-hmrc-play-28"     % "8.5.0",
-    "uk.gov.hmrc"         %% "play-conditional-form-mapping"  % "1.13.0-play-28",
-    "uk.gov.hmrc"         %% "domain"                         % "8.3.0-play-28",
-    "uk.gov.hmrc"         %% "bootstrap-frontend-play-28"     % bootstrapVersion,
-    "org.typelevel"       %% "cats-core"                      % "2.10.0",
-    "uk.gov.hmrc"         %% "tax-year"                       % "4.0.0"
+    "uk.gov.hmrc"   %% "play-frontend-hmrc-play-30"            % bootstrapVersion,
+    "uk.gov.hmrc"   %% "bootstrap-frontend-play-30"            % bootstrapVersion,
+    "uk.gov.hmrc"   %% "play-conditional-form-mapping-play-30" % "2.0.0",
+    "uk.gov.hmrc"   %% "domain-play-30"                        % "9.0.0",
+    "org.typelevel" %% "cats-core"                             % "2.10.0",
+    "uk.gov.hmrc"   %% "tax-year"                              % "4.0.0"
   )
 
   val test: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-28"   % bootstrapVersion,
+    "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootstrapVersion,
     "org.scalatest"           %% "scalatest"                % "3.2.18",
     "org.scalatestplus"       %% "scalacheck-1-17"          % "3.2.18.0",
     "org.jsoup"                % "jsoup"                    % "1.17.2",
-    "org.mockito"             %% "mockito-scala-scalatest"  % "1.17.30",
-    "org.scalacheck"          %% "scalacheck"               % "1.17.0",
-    "org.wiremock"             % "wiremock-standalone"      % "3.4.2",
+    "org.mockito"             %% "mockito-scala-scalatest"  % "1.17.31",
+    "org.scalacheck"          %% "scalacheck"               % "1.18.0",
+    "org.wiremock"             % "wiremock-standalone"      % "3.5.4",
     "wolfendale"              %% "scalacheck-gen-regexp"    % "0.1.2",
     "com.vladsch.flexmark"     % "flexmark-all"             % "0.64.8"
   ).map(_ % Test)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.9.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,15 +1,11 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-// To resolve a bug with version 2.x.x of the scoverage plugin - https://github.com/sbt/sbt/issues/6997
-// Try to remove when sbt 1.8.0+ and scoverage is 2.0.7+
-ThisBuild / libraryDependencySchemes += "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
-
-addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.20.0")
-addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.2.0")
-addSbtPlugin("com.typesafe.play"    % "sbt-plugin"            % "2.8.20")
-addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "1.0.0")
-addSbtPlugin("org.scoverage"        % "sbt-scoverage"         % "2.0.9")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-auto-build"        % "3.21.0")
+addSbtPlugin("uk.gov.hmrc"          % "sbt-distributables"    % "2.5.0")
+addSbtPlugin("org.playframework"    % "sbt-plugin"            % "3.0.2")
+addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
+addSbtPlugin("org.scoverage"        % "sbt-scoverage"         % "2.0.11")
 addSbtPlugin("io.github.irundaia"   % "sbt-sassify"           % "1.5.2")
 addSbtPlugin("net.ground5hark.sbt"  % "sbt-concat"            % "0.2.0")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-uglify"            % "2.0.0")

--- a/test/resources/test.application.conf
+++ b/test/resources/test.application.conf
@@ -17,13 +17,6 @@ include "application.conf"
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 play.filters.disabled += "play.filters.csp.CSPFilter"
 
-mongo-async-driver {
-  akka {
-    log-dead-letters-during-shutdown = off
-    log-dead-letters = 0
-  }
-}
-
 auditing {
   enabled = false
   consumer {


### PR DESCRIPTION
Play 3.0 migration.
Note that `play-frontend-hmrc-play-30` has not been updated past 8.5.0 because moving to version 9 causes the Twirl templates to break.